### PR TITLE
Improve JSON error handling in tool parser

### DIFF
--- a/verl/hermes_tool_parser.py
+++ b/verl/hermes_tool_parser.py
@@ -1,0 +1,17 @@
+import json
+import logging
+
+def extract_tool_calls(response):
+    try:
+        raw_function_calls = [
+            json.loads(match[0]) for match in extract_matches(response)
+        ]
+    except json.JSONDecodeError as e:
+        logging.error(f"JSON decode error: {e} in response: {response}")
+        return []
+    except Exception as e:
+        logging.error(f"Unexpected error: {e} in response: {response}")
+        return []
+
+    # Continue processing raw_function_calls
+    return raw_function_calls


### PR DESCRIPTION
The issue seems to stem from a failure to extract tool calls from JSON responses, likely due to malformed or unexpected JSON formats. We need to enhance the error handling in the `hermes_tool_parser.py` to better manage JSON parsing errors, possibly by adding checks before attempting to parse the JSON and logging the problematic responses for easier debugging.

Fixes #10