### PR TITLE
fix(videommmu): split malformed process_results / generation_kwargs lines

### DIFF
--- a/lmms_eval_tasks/videommmu/adaptation_tool.yaml
+++ b/lmms_eval_tasks/videommmu/adaptation_tool.yaml
@@ -3,5 +3,6 @@ task: "video_mmmu_adaptation_reasoning_tool"
 doc_to_text: !function utils.videommmu_doc_to_text_adaptation
 doc_to_messages: !function utils.videommmu_tool_doc_to_messages_adaptation
 include: _default_template_yaml
-process_results: !function utils.videommmu_process_results_adaptationgeneration_kwargs:
+process_results: !function utils.videommmu_process_results_adaptation
+generation_kwargs:
   max_new_tokens: 49152

--- a/lmms_eval_tasks/videommmu/comprehension_tool.yaml
+++ b/lmms_eval_tasks/videommmu/comprehension_tool.yaml
@@ -3,5 +3,6 @@ task: "video_mmmu_comprehension_reasoning_tool"
 doc_to_text: !function utils.videommmu_doc_to_text_perception_comprehension
 doc_to_messages: !function utils.videommmu_tool_doc_to_messages_perception_comprehension
 include: _default_template_yaml
-process_results: !function utils.videommmu_process_results_perception_comprehensiongeneration_kwargs:
+process_results: !function utils.videommmu_process_results_perception_comprehension
+generation_kwargs:
   max_new_tokens: 49152

--- a/lmms_eval_tasks/videommmu/perception_tool.yaml
+++ b/lmms_eval_tasks/videommmu/perception_tool.yaml
@@ -3,5 +3,6 @@ task: "video_mmmu_perception_reasoning_tool"
 doc_to_text: !function utils.videommmu_doc_to_text_perception_comprehension
 doc_to_messages: !function utils.videommmu_tool_doc_to_messages_perception_comprehension
 include: _default_template_yaml
-process_results: !function utils.videommmu_process_results_perception_comprehensiongeneration_kwargs:
+process_results: !function utils.videommmu_process_results_perception_comprehension
+generation_kwargs:
   max_new_tokens: 49152


### PR DESCRIPTION
Closes #22.

## Problem

The three VideoMMMU tool task YAMLs failed to load with `ScannerError: mapping values are not allowed here`:

- `lmms_eval_tasks/videommmu/adaptation_tool.yaml`
- `lmms_eval_tasks/videommmu/comprehension_tool.yaml`
- `lmms_eval_tasks/videommmu/perception_tool.yaml`

A prior commit accidentally concatenated `generation_kwargs:` onto the end of the `process_results: !function ...` line, producing two `:` tokens on one line and an invalid `!function` target.

## Fix

Split the two keys onto separate lines. After the fix, all three YAMLs load cleanly through `lmms_eval/utils.py:load_yaml_config`, and the `max_new_tokens: 49152` override is applied via shallow merge on top of the 4096-token default in `_default_template_yaml`.

## Verification

- Repo-wide YAML smoke test: 142/142 task YAMLs now parse (was 139/142).
- `video_mmmu_{adaptation,comprehension,perception}_reasoning_tool` task configs load with `generation_kwargs.max_new_tokens == 49152`.
- No other files touched.